### PR TITLE
Using new version of Selenium

### DIFF
--- a/easy_page_speed_screenshots/config.py
+++ b/easy_page_speed_screenshots/config.py
@@ -6,21 +6,19 @@ DEV_MODE = False
 try:
     base_path = sys._MEIPASS
 except Exception:
-    base_path = os.path.dirname(__file__)
+    base_path = os.path.dirname(os.path.dirname(__file__))
 
 # constant
 
 # Path
-if getattr(sys, 'frozen', False): # check if current run time is exe file
-    ASSET_FOLDER = os.path.join(base_path, 'assets')
+if getattr(sys, "frozen", False):  # check if current run time is exe file
+    ASSET_FOLDER = os.path.join(base_path, "assets")
     FAVICON_PATH = base_path + "\\favicon.ico"
     ICON_FOLDER_PATH = base_path + "\icon-folder.png"
-    DRIVER_PATH = base_path + '\chromedriver.exe'
-else: # script file
-    ASSET_FOLDER = os.path.join(base_path, '../assets')
-    FAVICON_PATH = ASSET_FOLDER + "/images/favicon.ico"
-    ICON_FOLDER_PATH = ASSET_FOLDER + "/images/icon-folder.png"
-    DRIVER_PATH = ASSET_FOLDER + '/driver/chromedriver.exe'
+else:  # script file
+    ASSET_FOLDER = base_path + "\\assets"
+    FAVICON_PATH = ASSET_FOLDER + "\images\\favicon.ico"
+    ICON_FOLDER_PATH = ASSET_FOLDER + "\images\icon-folder.png"
 
 PS_URL = "https://pagespeed.web.dev/"
 GM_URL = "https://gtmetrix.com/"
@@ -74,4 +72,3 @@ txt_quit_message = "Are you sure you want to exit?"
 
 txt_placeholder_folder = "Choose output directory"
 txt_placeholder_apikey = "API Key"
-

--- a/easy_page_speed_screenshots/helpers.py
+++ b/easy_page_speed_screenshots/helpers.py
@@ -53,7 +53,7 @@ def epss_content_loaded(driver, selector):
 # get webdriver with options
 def epss_get_webdriver():
     chrome_service = ChromeService()
-    chrome_service.creationflags = CREATE_NO_WINDOW
+    chrome_service.creation_flags = CREATE_NO_WINDOW
     return webdriver.Chrome(
         service=chrome_service,
         options=options,

--- a/easy_page_speed_screenshots/helpers.py
+++ b/easy_page_speed_screenshots/helpers.py
@@ -12,6 +12,8 @@ from selenium.webdriver.support import expected_conditions as EC
 from urllib.parse import urlparse
 from urllib.parse import parse_qs
 import os.path
+from selenium.webdriver.chrome.service import Service as ChromeService
+from subprocess import CREATE_NO_WINDOW
 
 from . import config
 
@@ -50,8 +52,10 @@ def epss_content_loaded(driver, selector):
 
 # get webdriver with options
 def epss_get_webdriver():
+    chrome_service = ChromeService()
+    chrome_service.creationflags = CREATE_NO_WINDOW
     return webdriver.Chrome(
-        executable_path=config.DRIVER_PATH,
+        service=chrome_service,
         options=options,
     )
 


### PR DESCRIPTION
@daomapsieucap I just finished fixing the problem with `chromedriver`, can you take a look? Thank you!!

From version 4.6 or higher, we don't need to explicitly import `chromedriver` with Selenium, it will automatically pick the suitable version. So I just simply `executable_path` and `DRIVER_PATH`

This leads to a new problem: `chromedriver` will be downloaded and run in system's cache folder `.cache/` which will open a console window. I have also handled it with 

```python
chrome_service = ChromeService()
chrome_service.creation_flags = CREATE_NO_WINDOW
```